### PR TITLE
Release 1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug caused by untested merge request
+
 ## [1.10.1] - 28.11.2024
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,8 +82,8 @@ dependencies = [
 
 [[package]]
 name = "anime-launcher-sdk"
-version = "1.23.0"
-source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.23.0#2671c0408fa52596c1706bb9c78c1b760fc44c6e"
+version = "1.24.0"
+source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.24.0#d516dff1820aee068feab3607cdc1de2d3e7b77d"
 dependencies = [
  "anime-game-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ glib-build-tools = "0.20"
 
 [dependencies.anime-launcher-sdk]
 git = "https://github.com/an-anime-team/anime-launcher-sdk"
-tag = "1.23.0"
+tag = "1.24.0"
 features = ["all", "honkai", "honkai-patch"]
 
 # path = "../anime-launcher-sdk" # ! for dev purposes only

--- a/src/ui/about.rs
+++ b/src/ui/about.rs
@@ -103,7 +103,7 @@ impl SimpleComponent for AboutDialog {
                 "<p>Fixed</p>",
 
                 "<ul>",
-                    "<li>Fixed a typo in the background image chooser</li>",
+                    "<li>Fixed a bug caused by untested merge request</li>",
                 "</ul>"
             ].join("\n"),
 


### PR DESCRIPTION
# Short description

Fixed a bug caused by untested merge request in the launcher SDK. This launcher was the only one using the SDK after this merge request so other ones were not affected.

Fixes https://github.com/an-anime-team/honkers-launcher/issues/58.

# Roadmap

- [x] Freeze major code changes
- [x] Update `CHANGELOG.md` and `about.rs`'s changelog
- [x] Release 1.10.2